### PR TITLE
fix: add error handling for UYU currency

### DIFF
--- a/btc_price.py
+++ b/btc_price.py
@@ -46,9 +46,23 @@ def get_current_prices():
         
         data = response.json()
         
+        # Get USD price and change (required)
         current_price_usd = data['bitcoin']['usd']
-        current_price_uyu = data['bitcoin']['uyu']
         price_change_usd = data['bitcoin'].get('usd_24h_change', 0)
+        
+        # Try to get UYU price, use converted USD price as fallback
+        try:
+            current_price_uyu = data['bitcoin'].get('uyu')
+            if current_price_uyu is None:
+                # If UYU is not available, use a fallback conversion rate (example: 1 USD = 39.5 UYU)
+                fallback_uyu_rate = 39.5
+                current_price_uyu = current_price_usd * fallback_uyu_rate
+                print("Warning: UYU price not available from API, using estimated conversion")
+        except (KeyError, TypeError):
+            # If there's any error getting UYU price, use the fallback
+            fallback_uyu_rate = 39.5
+            current_price_uyu = current_price_usd * fallback_uyu_rate
+            print("Warning: UYU price not available from API, using estimated conversion")
         
         return current_price_usd, current_price_uyu, price_change_usd
     


### PR DESCRIPTION
This PR fixes the KeyError when accessing 'uyu' currency by adding proper error handling and a fallback conversion mechanism.

## Changes Made
1. Added error handling when accessing UYU price
2. Implemented a fallback mechanism that uses an estimated USD to UYU conversion rate
3. Added warning messages when falling back to estimated conversion
4. Added proper error handling for the API response

## Testing
- Tested with API when UYU is not available
- Verified fallback conversion works correctly
- Confirmed warning messages are displayed appropriately

Fixes #3 